### PR TITLE
fix initail state

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -22,7 +22,7 @@ const buildState = (defaultState) => {
   if (defaultState.channels) {
     state.channels.push(...defaultState.channels);
   }
-  if (state.currentChannelId) {
+  if (defaultState.currentChannelId) {
     state.currentChannelId = defaultState.currentChannelId;
   }
 


### PR DESCRIPTION
При определении начального состояния не определяется currentChannel, вернее он перезаписывается значением undefined, и не попадает в объект gon.