### PR TITLE
update react-overlays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14730,7 +14730,7 @@
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^4.1.0",
+        "react-overlays": "^4.1.1",
         "react-transition-group": "^4.4.1",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
@@ -14773,15 +14773,15 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-overlays": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.0.tgz",
-      "integrity": "sha512-vdRpnKe0ckWOOD9uWdqykLUPHLPndIiUV7XfEKsi5008xiyHCfL8bxsx4LbMrfnxW1LzRthLyfy50XYRFNQqqw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-4.1.1.tgz",
+      "integrity": "sha512-WtJifh081e6M24KnvTQoNjQEpz7HoLxqt8TwZM7LOYIkYJ8i/Ly1Xi7RVte87ZVnmqQ4PFaFiNHZhSINPSpdBQ==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "@popperjs/core": "^2.0.0",
-        "@restart/hooks": "^0.3.12",
+        "@babel/runtime": "^7.12.1",
+        "@popperjs/core": "^2.5.3",
+        "@restart/hooks": "^0.3.25",
         "@types/warning": "^3.0.0",
-        "dom-helpers": "^5.1.0",
+        "dom-helpers": "^5.2.0",
         "prop-types": "^15.7.2",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"


### PR DESCRIPTION
Fix for `Dropdown` from `react-bootstrap` bug. Look [this issue](https://github.com/react-bootstrap/react-bootstrap/issues/5409).