### PR TITLE
change webpack rule

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -28,6 +28,9 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
+        resolve: {
+          fullySpecified: false,
+        },
         exclude: /node_modules/,
         use: 'babel-loader',
       },


### PR DESCRIPTION
Allows
`import './myModule'`
instead of
`import './myModule/index.js'`

https://webpack.js.org/configuration/module/#resolvefullyspecified